### PR TITLE
[DEV-11058] Allow providing cdnUrl and integrations properties

### DIFF
--- a/packages/analytics-nextjs/src/context.tsx
+++ b/packages/analytics-nextjs/src/context.tsx
@@ -156,7 +156,7 @@ export function AnalyticsContextProvider({
                         // Disable calls to Segment API completely if no Write Key is provided
                         ...(!writeKey && {
                             // eslint-disable-next-line @typescript-eslint/naming-convention
-                            integrations: { ...integrations, 'Segment.io': false },
+                            integrations: { 'Segment.io': false },
                         }),
                     },
                 );

--- a/packages/analytics-nextjs/src/context.tsx
+++ b/packages/analytics-nextjs/src/context.tsx
@@ -1,4 +1,10 @@
-import type { Analytics, CookieOptions, Plugin, UserOptions } from '@segment/analytics-next';
+import type {
+    Analytics,
+    CookieOptions,
+    Integrations,
+    Plugin,
+    UserOptions,
+} from '@segment/analytics-next';
 import { AnalyticsBrowser } from '@segment/analytics-next';
 import PlausibleProvider from 'next-plausible';
 import type { PropsWithChildren } from 'react';
@@ -25,7 +31,9 @@ interface Context {
 }
 
 interface Props {
+    cdnUrl?: string;
     cookie?: CookieOptions;
+    integrations?: Integrations;
     isEnabled?: boolean;
     newsroom?: PickedNewsroomProperties;
     story?: PickedStoryProperties;
@@ -88,8 +96,10 @@ function PlausibleWrapperMaybe({
 }
 
 export function AnalyticsContextProvider({
+    cdnUrl,
     children,
     cookie = {},
+    integrations,
     isEnabled = true,
     newsroom,
     story,
@@ -119,6 +129,8 @@ export function AnalyticsContextProvider({
                 const [response] = await AnalyticsBrowser.load(
                     {
                         writeKey,
+                        // eslint-disable-next-line @typescript-eslint/naming-convention
+                        cdnURL: cdnUrl,
                         // If no Segment Write Key is provided, we initialize the library settings manually
                         ...(!writeKey && {
                             cdnSettings: {
@@ -139,6 +151,7 @@ export function AnalyticsContextProvider({
                             domain: document.location.host,
                             ...cookie,
                         },
+                        integrations,
                         user,
                         // Disable calls to Segment API completely if no Write Key is provided
                         ...(!writeKey && {
@@ -165,7 +178,18 @@ export function AnalyticsContextProvider({
             loadAnalytics(segmentWriteKey || '');
         }
         // eslint-disable-next-line react-hooks/exhaustive-deps
-    }, [segmentWriteKey, isEnabled, trackingPolicy, uuid, plugins, JSON.stringify(cookie), user]);
+    }, [
+        segmentWriteKey,
+        isEnabled,
+        trackingPolicy,
+        uuid,
+        plugins,
+        // eslint-disable-next-line react-hooks/exhaustive-deps
+        JSON.stringify(cookie),
+        // eslint-disable-next-line react-hooks/exhaustive-deps
+        JSON.stringify(integrations),
+        user,
+    ]);
 
     useEffect(() => {
         if (!ignoreConsent && typeof consent === 'boolean') {

--- a/packages/analytics-nextjs/src/context.tsx
+++ b/packages/analytics-nextjs/src/context.tsx
@@ -179,16 +179,17 @@ export function AnalyticsContextProvider({
         }
         // eslint-disable-next-line react-hooks/exhaustive-deps
     }, [
-        segmentWriteKey,
+        cdnUrl,
         isEnabled,
-        trackingPolicy,
-        uuid,
-        plugins,
         // eslint-disable-next-line react-hooks/exhaustive-deps
         JSON.stringify(cookie),
         // eslint-disable-next-line react-hooks/exhaustive-deps
         JSON.stringify(integrations),
+        plugins,
+        segmentWriteKey,
+        trackingPolicy,
         user,
+        uuid,
     ]);
 
     useEffect(() => {

--- a/packages/analytics-nextjs/src/context.tsx
+++ b/packages/analytics-nextjs/src/context.tsx
@@ -156,7 +156,7 @@ export function AnalyticsContextProvider({
                         // Disable calls to Segment API completely if no Write Key is provided
                         ...(!writeKey && {
                             // eslint-disable-next-line @typescript-eslint/naming-convention
-                            integrations: { 'Segment.io': false },
+                            integrations: { ...integrations, 'Segment.io': false },
                         }),
                     },
                 );


### PR DESCRIPTION
We need to be able to customize both the CDN url so the library is loaded via a proxy as well as all the tracking calls to go through a proxy again.

See [DEV-11058](https://linear.app/prezly/issue/DEV-11058/proxy-segment-calls) for details.