### PR TITLE
[DEV-11376] Allow providing properties for page calls

### DIFF
--- a/lerna.json
+++ b/lerna.json
@@ -1,8 +1,10 @@
 {
-  "packages": ["packages/*"],
+  "packages": [
+    "packages/*"
+  ],
   "publishConfig": {
     "access": "public"
   },
   "useWorkspaces": true,
-  "version": "1.9.0"
+  "version": "1.10.0"
 }

--- a/lerna.json
+++ b/lerna.json
@@ -6,5 +6,5 @@
     "access": "public"
   },
   "useWorkspaces": true,
-  "version": "1.10.1"
+  "version": "1.10.2"
 }

--- a/lerna.json
+++ b/lerna.json
@@ -6,5 +6,5 @@
     "access": "public"
   },
   "useWorkspaces": true,
-  "version": "1.10.0"
+  "version": "1.10.1"
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -17080,7 +17080,7 @@
     },
     "packages/analytics-nextjs": {
       "name": "@prezly/analytics-nextjs",
-      "version": "1.10.0",
+      "version": "1.10.1",
       "license": "MIT",
       "dependencies": {
         "@react-hookz/web": "^14.2.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -17080,7 +17080,7 @@
     },
     "packages/analytics-nextjs": {
       "name": "@prezly/analytics-nextjs",
-      "version": "1.9.0",
+      "version": "1.10.0",
       "license": "MIT",
       "dependencies": {
         "@react-hookz/web": "^14.2.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -17080,7 +17080,7 @@
     },
     "packages/analytics-nextjs": {
       "name": "@prezly/analytics-nextjs",
-      "version": "1.10.1",
+      "version": "1.10.2",
       "license": "MIT",
       "dependencies": {
         "@react-hookz/web": "^14.2.2",

--- a/packages/analytics-nextjs/src/components/Analytics.tsx
+++ b/packages/analytics-nextjs/src/components/Analytics.tsx
@@ -1,7 +1,6 @@
 import { usePrevious, useSyncedRef } from '@react-hookz/web';
 import { useRouter } from 'next/router';
 import Script from 'next/script';
-import { usePlausible } from 'next-plausible';
 import { useEffect } from 'react';
 
 import { useAnalyticsContext } from '../context';
@@ -18,7 +17,6 @@ import {
 export function Analytics() {
     const { alias, identify, newsroom, page, track, user } = useAnalytics();
     const { onPageView } = useAnalyticsContext();
-    const plausible = usePlausible();
     const aliasRef = useSyncedRef(alias);
     const identifyRef = useSyncedRef(identify);
     const trackRef = useSyncedRef(track);
@@ -30,9 +28,8 @@ export function Analytics() {
         if (currentPath !== previousPath) {
             const data = onPageView?.() || {};
             page(undefined, undefined, data);
-            plausible('pageview', { props: data });
         }
-    }, [currentPath, onPageView, page, plausible, previousPath]);
+    }, [currentPath, onPageView, page, previousPath]);
 
     /**
      * @deprecated Improved campaign click tracking supersedes this functionality. To be removed in v2.0

--- a/packages/analytics-nextjs/src/components/Analytics.tsx
+++ b/packages/analytics-nextjs/src/components/Analytics.tsx
@@ -1,8 +1,10 @@
 import { usePrevious, useSyncedRef } from '@react-hookz/web';
 import { useRouter } from 'next/router';
 import Script from 'next/script';
+import { usePlausible } from 'next-plausible';
 import { useEffect } from 'react';
 
+import { useAnalyticsContext } from '../context';
 import { CAMPAIGN } from '../events';
 import { useAnalytics } from '../hooks';
 import {
@@ -15,6 +17,8 @@ import {
 
 export function Analytics() {
     const { alias, identify, newsroom, page, track, user } = useAnalytics();
+    const { onPageView } = useAnalyticsContext();
+    const plausible = usePlausible();
     const aliasRef = useSyncedRef(alias);
     const identifyRef = useSyncedRef(identify);
     const trackRef = useSyncedRef(track);
@@ -24,9 +28,11 @@ export function Analytics() {
 
     useEffect(() => {
         if (currentPath !== previousPath) {
-            page();
+            const data = onPageView?.() || {};
+            page(undefined, undefined, data);
+            plausible('pageview', { props: data });
         }
-    }, [currentPath, page, previousPath]);
+    }, [currentPath, onPageView, page, plausible, previousPath]);
 
     /**
      * @deprecated Improved campaign click tracking supersedes this functionality. To be removed in v2.0

--- a/packages/analytics-nextjs/src/context.tsx
+++ b/packages/analytics-nextjs/src/context.tsx
@@ -25,8 +25,9 @@ interface Context {
      */
     isUserConsentGiven: boolean | null;
     newsroom?: PickedNewsroomProperties;
-    story?: PickedStoryProperties;
+    onPageView?: () => Record<string, any>;
     setConsent: (consent: boolean) => void;
+    story?: PickedStoryProperties;
     trackingPolicy: TrackingPolicy;
 }
 
@@ -40,6 +41,10 @@ interface Props {
      */
     isPlausibleEnabled?: boolean;
     newsroom?: PickedNewsroomProperties;
+    /**
+     * Allow passing along extra properties to page tracking calls.
+     */
+    onPageView?: () => Record<string, any>;
     story?: PickedStoryProperties;
     plugins?: Plugin[];
     segmentWriteKey?: string;
@@ -80,6 +85,7 @@ function PlausibleWrapperMaybe({
     return (
         <PlausibleProvider
             domain={plausibleDomain ?? newsroom.plausible_site_id}
+            manualPageviews
             scriptProps={{
                 src: 'https://atlas.prezly.com/js/script.js',
                 // This is a documented parameter, but it's not reflected in the types
@@ -103,16 +109,17 @@ export function AnalyticsContextProvider({
     cdnUrl,
     children,
     cookie = {},
+    ignoreConsent,
     integrations,
     isEnabled = true,
     isPlausibleEnabled,
     newsroom,
-    story,
+    onPageView,
+    plausibleDomain,
     plugins,
     segmentWriteKey: customSegmentWriteKey,
-    plausibleDomain,
+    story,
     user,
-    ignoreConsent,
 }: PropsWithChildren<Props>) {
     const {
         tracking_policy: trackingPolicy,
@@ -211,6 +218,7 @@ export function AnalyticsContextProvider({
                 isEnabled,
                 isUserConsentGiven,
                 newsroom,
+                onPageView,
                 story,
                 setConsent,
                 trackingPolicy,

--- a/packages/analytics-nextjs/src/context.tsx
+++ b/packages/analytics-nextjs/src/context.tsx
@@ -85,7 +85,6 @@ function PlausibleWrapperMaybe({
     return (
         <PlausibleProvider
             domain={plausibleDomain ?? newsroom.plausible_site_id}
-            manualPageviews
             scriptProps={{
                 src: 'https://atlas.prezly.com/js/script.js',
                 // This is a documented parameter, but it's not reflected in the types
@@ -94,7 +93,6 @@ function PlausibleWrapperMaybe({
                 // eslint-disable-next-line @typescript-eslint/naming-convention
                 'data-api': 'https://atlas.prezly.com/api/event',
             }}
-            trackLocalhost
         >
             {/* 
                 This is the only way I found to test if the PlausibleProvider is rendered. 

--- a/packages/analytics-nextjs/src/context.tsx
+++ b/packages/analytics-nextjs/src/context.tsx
@@ -94,6 +94,7 @@ function PlausibleWrapperMaybe({
                 // eslint-disable-next-line @typescript-eslint/naming-convention
                 'data-api': 'https://atlas.prezly.com/api/event',
             }}
+            trackLocalhost
         >
             {/* 
                 This is the only way I found to test if the PlausibleProvider is rendered. 

--- a/packages/analytics-nextjs/src/version.ts
+++ b/packages/analytics-nextjs/src/version.ts
@@ -1,1 +1,1 @@
-export const version = '1.9.0';
+export const version = '1.10.0';

--- a/packages/analytics-nextjs/src/version.ts
+++ b/packages/analytics-nextjs/src/version.ts
@@ -1,1 +1,1 @@
-export const version = '1.10.0';
+export const version = '1.10.1';

--- a/packages/analytics-nextjs/src/version.ts
+++ b/packages/analytics-nextjs/src/version.ts
@@ -1,1 +1,1 @@
-export const version = '1.10.1';
+export const version = '1.10.2';


### PR DESCRIPTION
Added `onPageView` callback that will be triggered every time a `page` view tracking call is about to be called. Via this callback, you can provide additional properties to be tracked along with this request.

This also applies to Plausible, which required us to disable the automatic page view tracking and we're now instead triggering it manually.