### PR TITLE
[DEV-12776] Remove automatic page tracking call

### DIFF
--- a/packages/analytics-nextjs/src/components/Analytics.tsx
+++ b/packages/analytics-nextjs/src/components/Analytics.tsx
@@ -1,27 +1,15 @@
 'use client';
 
-import { usePrevious, useSyncedRef } from '@react-hookz/web';
-import { usePathname } from 'next/navigation';
+import { useSyncedRef } from '@react-hookz/web';
 import Script from 'next/script';
 import { useEffect } from 'react';
 
-import { useAnalyticsContext } from '../context';
 import { ACTIONS } from '../events';
 import { useAnalytics } from '../hooks';
 
 export function Analytics() {
-    const { newsroom, page, track } = useAnalytics();
-    const { onPageView } = useAnalyticsContext();
+    const { newsroom, track } = useAnalytics();
     const trackRef = useSyncedRef(track);
-    const currentPath = usePathname();
-    const previousPath = usePrevious(currentPath);
-
-    useEffect(() => {
-        if (currentPath && currentPath !== previousPath) {
-            const data = onPageView?.() || {};
-            page(undefined, undefined, data);
-        }
-    }, [currentPath, onPageView, page, previousPath]);
 
     useEffect(() => {
         function handleClick(event: MouseEvent) {

--- a/packages/analytics-nextjs/src/context.tsx
+++ b/packages/analytics-nextjs/src/context.tsx
@@ -22,7 +22,6 @@ interface Context {
      */
     isUserConsentGiven: boolean | null;
     newsroom?: PickedNewsroomProperties;
-    onPageView?: () => Record<string, any>;
     setConsent: (consent: boolean) => void;
     story?: PickedStoryProperties;
     trackingPolicy: TrackingPolicy;
@@ -38,10 +37,6 @@ interface Props {
      */
     isPlausibleEnabled?: boolean;
     newsroom?: PickedNewsroomProperties;
-    /**
-     * Allow passing along extra properties to page tracking calls.
-     */
-    onPageView?: () => Record<string, any>;
     story?: PickedStoryProperties;
     plugins?: Plugin[];
     segmentWriteKey?: string;
@@ -110,7 +105,6 @@ export function AnalyticsContextProvider({
     isEnabled = true,
     isPlausibleEnabled,
     newsroom,
-    onPageView,
     plausibleDomain,
     plugins,
     segmentWriteKey: customSegmentWriteKey,
@@ -214,7 +208,6 @@ export function AnalyticsContextProvider({
                 isEnabled,
                 isUserConsentGiven,
                 newsroom,
-                onPageView,
                 story,
                 setConsent,
                 trackingPolicy,


### PR DESCRIPTION
In order to have more control over when `page` tracking call is fired, I'm disabling the automatic `page` call in this package and it is now the responsibility of the consumer code to trigger this.

This also means we no longer need `onPageView` prop, since you can pass the data directly to the `page` function.

This change is needed to fix https://github.com/prezly/theme-nextjs-bea/pull/1126.