### PR TITLE
[DEV-19486] Feature - Lazy consent setup

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -25,7 +25,7 @@
         "prettier": "3.5.0",
         "rimraf": "3.0.2",
         "ts-jest": "28.0.8",
-        "typescript": "5.4.4"
+        "typescript": "5.7.3"
       },
       "optionalDependencies": {
         "@nx/nx-linux-x64-gnu": "18.0.4"
@@ -12532,7 +12532,9 @@
       "license": "MIT"
     },
     "node_modules/typescript": {
-      "version": "5.4.4",
+      "version": "5.7.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.7.3.tgz",
+      "integrity": "sha512-84MVSjMEHP+FQRPy3pX9sTVV/INIex71s9TL2Gm5FG/WG1SqXeKyZ0k7/blY/4FdOzI12CBy1vGc4og/eus0fw==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {

--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "prettier": "3.5.0",
     "rimraf": "3.0.2",
     "ts-jest": "28.0.8",
-    "typescript": "5.4.4"
+    "typescript": "5.7.3"
   },
   "optionalDependencies": {
     "@nx/nx-linux-x64-gnu": "18.0.4"

--- a/packages/analytics-nextjs/src/Analytics.ts
+++ b/packages/analytics-nextjs/src/Analytics.ts
@@ -68,7 +68,8 @@ export class Analytics {
     }
 
     public async init(config: Config) {
-        if (this.isInitialized) {
+        if (this.config) {
+            // Cannot re-initialize analytics
             return;
         }
 

--- a/packages/analytics-nextjs/src/Analytics.ts
+++ b/packages/analytics-nextjs/src/Analytics.ts
@@ -51,6 +51,9 @@ export class Analytics {
     }
 
     get permissions() {
+        if (typeof this.config === 'undefined' || typeof this.consent === 'undefined') {
+            throw new Error('Cannot check permissions before analytics initialization');
+        }
         return getTrackingPermissions({
             consent: this.consent,
             trackingPolicy: this.config!.trackingPolicy,

--- a/packages/analytics-nextjs/src/Analytics.ts
+++ b/packages/analytics-nextjs/src/Analytics.ts
@@ -164,7 +164,10 @@ export class Analytics {
     }
 
     private get meta() {
-        console.warn('Tracking without Prezly meta being set');
+        if (!this._meta) {
+            console.warn('Tracking without Prezly meta being set');
+        }
+
         return this._meta;
     }
 

--- a/packages/analytics-nextjs/src/Analytics.ts
+++ b/packages/analytics-nextjs/src/Analytics.ts
@@ -205,8 +205,8 @@ export class Analytics {
                 this.loadSegment();
             }
 
-            if (this.identity && this.permissions.canIdentify) {
-                const { identity } = this;
+            const { identity } = this;
+            if (identity && this.permissions.canIdentify) {
                 this.segment?.identify(
                     identity.userId,
                     { ...identity.traits, prezly: this.meta },

--- a/packages/analytics-nextjs/src/Analytics.ts
+++ b/packages/analytics-nextjs/src/Analytics.ts
@@ -8,6 +8,7 @@ import {
     DEFERRED_USER_LOCAL_STORAGE_KEY,
     NULL_USER,
 } from './constants';
+import { checkIsConsentEqual } from './lib/compareConsent';
 import { getTrackingPermissions } from './lib/getTrackingPermissions';
 import { logToConsole, normalizePrezlyMetaPlugin, sendEventToPrezlyPlugin } from './plugins';
 import type { Config, Consent, Identity, PrezlyMeta } from './types';
@@ -170,6 +171,10 @@ export class Analytics {
     public setConsent(consent: Consent) {
         if (!this.config) {
             throw new Error('Cannot set consent before analytics initialization');
+        }
+
+        if (checkIsConsentEqual(consent, this.consent)) {
+            return;
         }
 
         this.consent = consent;

--- a/packages/analytics-nextjs/src/Analytics.ts
+++ b/packages/analytics-nextjs/src/Analytics.ts
@@ -4,7 +4,6 @@ import type { AnalyticsBrowser, Plugin } from '@segment/analytics-next';
 import type Plausible from 'plausible-tracker';
 
 import {
-    DEFAULT_CONSENT,
     DEFAULT_PLAUSIBLE_API_HOST,
     DEFERRED_USER_LOCAL_STORAGE_KEY,
     NULL_USER,
@@ -18,7 +17,7 @@ export class Analytics {
 
     private meta: PrezlyMeta | undefined;
 
-    public consent: Consent = DEFAULT_CONSENT;
+    public consent: Consent | undefined = undefined;
 
     public segment: AnalyticsBrowser | undefined;
 

--- a/packages/analytics-nextjs/src/Analytics.ts
+++ b/packages/analytics-nextjs/src/Analytics.ts
@@ -13,9 +13,11 @@ import { logToConsole, normalizePrezlyMetaPlugin, sendEventToPrezlyPlugin } from
 import type { Config, Consent, Identity, PrezlyMeta } from './types';
 
 export class Analytics {
+    /* eslint-disable @typescript-eslint/naming-convention */
     private _identity: Identity | undefined;
 
-    private meta: PrezlyMeta | undefined;
+    private _meta: PrezlyMeta | undefined;
+    /* eslint-enable @typescript-eslint/naming-convention */
 
     public consent: Consent | undefined = undefined;
 
@@ -102,7 +104,7 @@ export class Analytics {
         }
 
         if (config.meta) {
-            this.meta = config.meta;
+            this.setMeta(config.meta);
         }
     }
 
@@ -138,7 +140,12 @@ export class Analytics {
     }
 
     public setMeta(meta: PrezlyMeta) {
-        this.meta = meta;
+        this._meta = meta;
+    }
+
+    private get meta() {
+        console.warn('Tracking without Prezly meta being set');
+        return this._meta;
     }
 
     public setConsent(consent: Consent) {

--- a/packages/analytics-nextjs/src/Analytics.ts
+++ b/packages/analytics-nextjs/src/Analytics.ts
@@ -86,7 +86,7 @@ export class Analytics {
         }
     }
 
-    public async init(config: Config) {
+    public init = async (config: Config) => {
         if (this.config) {
             // Cannot re-initialize analytics
             return;
@@ -126,7 +126,7 @@ export class Analytics {
         }
 
         this.checkInitialized();
-    }
+    };
 
     private async loadSegment() {
         if (this.config?.segment === false) {
@@ -159,9 +159,9 @@ export class Analytics {
         );
     }
 
-    public setMeta(meta: PrezlyMeta) {
+    public setMeta = (meta: PrezlyMeta) => {
         this._meta = meta;
-    }
+    };
 
     private get meta() {
         if (!this._meta) {
@@ -171,7 +171,7 @@ export class Analytics {
         return this._meta;
     }
 
-    public setConsent(consent: Consent) {
+    public setConsent = (consent: Consent) => {
         if (!this.config) {
             throw new Error('Cannot set consent before analytics initialization');
         }
@@ -216,20 +216,20 @@ export class Analytics {
         });
 
         this.checkInitialized();
-    }
+    };
 
-    public async alias(userId: string, previousId: string) {
+    public alias = async (userId: string, previousId: string) => {
         await this.promises.init;
         await this.promises.segmentInit;
         await this.segment?.alias(userId, previousId, { integrations: this.integrations });
-    }
+    };
 
-    public async page(
+    public page = async (
         category?: string,
         name?: string,
         properties: object = {},
         callback?: () => void,
-    ) {
+    ) => {
         await this.promises.init;
         await this.promises.segmentInit;
         await this.segment?.page(
@@ -239,9 +239,9 @@ export class Analytics {
             { integrations: this.integrations },
             callback,
         );
-    }
+    };
 
-    public async track(event: string, properties: object = {}, callback?: () => void) {
+    public track = async (event: string, properties: object = {}, callback?: () => void) => {
         const props = this.meta ? { ...properties, prezly: this.meta } : properties;
 
         await this.promises.init;
@@ -256,9 +256,9 @@ export class Analytics {
                 this.segment?.track(event, props, { integrations: this.integrations }, callback),
             ),
         ]);
-    }
+    };
 
-    public async identify(userId: string, traits: object = {}, callback?: () => void) {
+    public identify = async (userId: string, traits: object = {}, callback?: () => void) => {
         this.identity = { userId, traits };
 
         await this.promises.init;
@@ -272,7 +272,7 @@ export class Analytics {
                 callback,
             );
         }
-    }
+    };
 
     public user() {
         return this.segment?.instance?.user() ?? NULL_USER;

--- a/packages/analytics-nextjs/src/Analytics.ts
+++ b/packages/analytics-nextjs/src/Analytics.ts
@@ -57,10 +57,6 @@ export class Analytics {
         });
     }
 
-    get isInitialized() {
-        return Boolean(this.config);
-    }
-
     get integrations() {
         return {
             Prezly: this.permissions.canTrackToPrezly,
@@ -149,8 +145,8 @@ export class Analytics {
     }
 
     public setConsent(consent: Consent) {
-        if (!this.isInitialized) {
-            throw new Error('Analytics uninitialized');
+        if (!this.config) {
+            throw new Error('Cannot set consent before analytics initialization');
         }
 
         this.consent = consent;

--- a/packages/analytics-nextjs/src/constants.ts
+++ b/packages/analytics-nextjs/src/constants.ts
@@ -1,10 +1,8 @@
-import { type Config, type Consent, TrackingPolicy } from './types';
+import { type Config, TrackingPolicy } from './types';
 
 export const DEFERRED_USER_LOCAL_STORAGE_KEY = 'identity';
 
 export const DEFAULT_PLAUSIBLE_API_HOST = 'https://atlas.prezly.com/api/event';
-
-export const DEFAULT_CONSENT: Consent = { categories: [] };
 
 export const DEFAULT_CONFIG: Config = {
     segment: {

--- a/packages/analytics-nextjs/src/lib/compareConsent.ts
+++ b/packages/analytics-nextjs/src/lib/compareConsent.ts
@@ -1,0 +1,18 @@
+import type { Consent } from '../types';
+
+export function checkIsConsentEqual(consent1: Consent | undefined, consent2: Consent | undefined) {
+    if (consent1 === consent2) {
+        return true;
+    }
+
+    if (typeof consent1 === 'undefined' || typeof consent2 === 'undefined') {
+        return false;
+    }
+
+    const containsSameCategories =
+        consent1.categories.length === consent2.categories.length &&
+        new Set([...consent1.categories, ...consent2.categories]).size ===
+            consent1.categories.length;
+
+    return containsSameCategories;
+}

--- a/packages/analytics-nextjs/src/lib/loadGoogleAnalytics.ts
+++ b/packages/analytics-nextjs/src/lib/loadGoogleAnalytics.ts
@@ -39,6 +39,12 @@ function loadAnalytics(analyticsId: string) {
 }
 
 export function loadGoogleAnalytics(analyticsId: string) {
+    const isLoaded = Boolean(document.getElementById('google-tag-manager-bootstrap'));
+
+    if (isLoaded) {
+        return;
+    }
+
     if (analyticsId.startsWith('GTM-')) {
         loadTagManager(analyticsId as `GTM-${string}`);
     } else {


### PR DESCRIPTION
Allow lazy initialization of consent. Setting consent is now part of initialization. Until ay consent is set analytics is assumed to be uninitialized.
This brings stability and ensures that we do not miss any event especially in cases like page tracking, which is fired right after page visit, and may occur before consent library reads previous user choice from any kind of storage.

Library will also warn that tracking is being done without setting Prezly meta.

Fixes GoogleAnalytics loading based on consent/tracking policy.